### PR TITLE
Add a vscode build task for typescript building convenience

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build:dev",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "npm: build:dev",
+			"detail": "rimraf prod; tsc && copyfiles -u 4 src/website/frontend/build/index.html src/website/frontend/build/**/* prod/website/frontend/build && copyfiles -u 1 src/commands/**/**/meta.json prod"
+		}
+	]
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply adds a build task for VSCode so that the TypeScript files can be built with CTRL + SHIFT + B

**Status and versioning classification:**
- Code changes have been tested on a local instance, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
