### PR TITLE
Fix deprecated parameter in BaseEmbed

### DIFF
--- a/src/util/BaseEmbed.ts
+++ b/src/util/BaseEmbed.ts
@@ -6,11 +6,11 @@ export default class BaseEmbed extends MessageEmbed {
 		const currentDate = new Date(Date.now());
 		this.setColor(0x000000);
 		this.setTitle(title);
-		this.setFooter(
-			`${title} requested by ${
+		this.setFooter({
+			text: `${title} requested by ${
 				user.tag
 			} • ${currentDate.getUTCMonth()}/${currentDate.getUTCDate()}/${currentDate.getUTCFullYear()} @ ${currentDate.getUTCHours()}:${currentDate.getUTCMinutes()} UTC`,
-			user.displayAvatarURL()
-		);
+			iconURL: user.displayAvatarURL(),
+		});
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the usage of a deprecated parameter in `MessageEmbed#setFooter` in `BaseEmbed.ts`

**Status and versioning classification:**
- Code changes have been tested on a local instance, or there are no code changes
