### PR TITLE
Fix _id overwrite

### DIFF
--- a/src/util/updateUser.ts
+++ b/src/util/updateUser.ts
@@ -10,6 +10,9 @@ export default async (
 	data: any
 ) => {
 	await client.userModel
-		.replaceOne({ guildID: guildID, userID: userID }, data)
+		.replaceOne(
+			{ guildID: guildID, userID: userID },
+			{ ...data, _id: undefined }
+		)
 		.exec();
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This prevents the _id field from being overwritten when a user is updated.

**Status and versioning classification:**
- Code changes have been tested on a local instance, or there are no code changes
